### PR TITLE
Add CORS pre-flight OPTIONS endpoints

### DIFF
--- a/APIs/ConfigurationAPI.raml
+++ b/APIs/ConfigurationAPI.raml
@@ -62,6 +62,11 @@ documentation:
               type: !include schemas/bulkProperties-get-response.json
               example: !include ../examples/bulkProperties-get-200.json
       options:
+        description: A pre-flight check generally used for Cross-Origin Resource Sharing (CORS) purposes
+        responses:
+          200:
+          403:
+      patch:
         description: 'Validate an NcBulkValuesHolder object against the Device Model'
         body:
           type: !include schemas/bulkProperties-validate-request.json
@@ -108,6 +113,11 @@ documentation:
             methodId:
                 type: string
                 pattern: "^[0-9]+m[0-9]+"
+        options:
+          description: A pre-flight check generally used for Cross-Origin Resource Sharing (CORS) purposes
+          responses:
+            200:
+            403:
         patch:
           description: 'Invoke method.'
           body:
@@ -181,6 +191,11 @@ documentation:
                 description: 'Returned when the Property was unable to be retrieved. Corresponds to NcMethodStatus code 500.'
                 body:
                   type: !include schemas/ms05-error.json
+          options:
+            description: A pre-flight check generally used for Cross-Origin Resource Sharing (CORS) purposes
+            responses:
+              200:
+              403:
           put:
             descriptions: 'Put value of a Property'
             body:


### PR DESCRIPTION
`OPTIONS` is already specified in other NMOS specifications (including [IS-04](https://specs.amwa.tv/is-04/releases/v1.3.2/docs/APIs_-_Server_Side_Implementation_Notes.html#cross-origin-resource-sharing-cors), [IS-05](https://specs.amwa.tv/is-05/releases/v1.0.1/docs/2.2._APIs_-_Server_Side_Implementation.html#cross-origin-resource-sharing-cors), [IS-08](https://specs.amwa.tv/is-08/releases/v1.0.1/docs/2.2._APIs_-_Server_Side_Implementation.html#cross-origin-resource-sharing-cors)) with a clause that covers *all* NMOS specifications:

> "In order to permit web-based control interfaces to be hosted remotely, all NMOS APIs MUST implement valid CORS HTTP headers in responses to all requests.
> In addition to this, where highlighted in the API specifications servers MUST respond to HTTP pre-flight OPTIONS requests. Servers MAY additionally support HTTP OPTIONS requests made to any other API resource."

This pull request:
- Changes "bulkProperties" `OPTIONS` endpoint to `PATCH`
- Adds pre-flight CORS `OPTIONS` to the "bulkProperties" endpoint
- Adds pre-flight CORS `OPTIONS` "value" endpoint 
- Adds pre-flight CORS `OPTIONS` "methods" endpoint